### PR TITLE
Fix build for windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,15 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Debug)]
 pub enum Error {
     InternalError,
+    TypeCastingError,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Internal libogg error")
+        match self {
+            Error::InternalError => write!(f, "Internal libogg error"),
+            Error::TypeCastingError => write!(f, "Type casting error"),
+        }
     }
 }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -6,11 +6,26 @@ pub struct Packet {
 }
 
 impl Packet {
+    #[cfg(not(target_os = "windows"))]
     pub fn new<'a, T: 'a + AsRef<[u8]>>(data: &T) -> Self {
         Packet {
             inner: ogg_packet {
                 packet: data.as_ref().as_ptr() as *mut u8,
                 bytes: data.as_ref().len() as i64,
+                b_o_s: 0,
+                e_o_s: 0,
+                granulepos: 0,
+                packetno: 0,
+            },
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn new<'a, T: 'a + AsRef<[u8]>>(data: &T) -> Self {
+        Packet {
+            inner: ogg_packet {
+                packet: data.as_ref().as_ptr() as *mut u8,
+                bytes: data.as_ref().len() as i32,
                 b_o_s: 0,
                 e_o_s: 0,
                 granulepos: 0,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::fmt;
 use std::mem;
 
@@ -19,34 +20,41 @@ impl Stream {
         }
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_lacing_storage(&self) -> i64 {
-        self.0.lacing_storage
+        self.0.lacing_storage.into()
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_lacing_fill(&self) -> i64 {
-        self.0.lacing_fill
+        self.0.lacing_fill.into()
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_lacing_packet(&self) -> i64 {
-        self.0.lacing_packet
+        self.0.lacing_packet.into()
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_lacing_returned(&self) -> i64 {
-        self.0.lacing_returned
+        self.0.lacing_returned.into()
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_body_storage(&self) -> i64 {
-        self.0.body_storage
+        self.0.body_storage.into()
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_body_fill(&self) -> i64 {
-        self.0.body_fill
+        self.0.body_fill.into()
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_body_returned(&self) -> i64 {
-        self.0.body_returned
+        self.0.body_returned.into()
     }
-    
+
     pub fn get_header(&self) -> &[u8; 282] {
         &self.0.header
     }
@@ -63,16 +71,22 @@ impl Stream {
         self.0.b_o_s
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_serialno(&self) -> i64 {
-        self.0.serialno
+        self.0.serialno.into()
     }
 
+    #[allow(clippy::useless_conversion)]
     pub fn get_pageno(&self) -> i64 {
-        self.0.pageno
+        self.0.pageno.into()
     }
 
-    pub fn set_pageno(&mut self, new_pageno: i64) {
-        self.0.pageno = new_pageno;
+    #[allow(clippy::useless_conversion)]
+    pub fn set_pageno(&mut self, new_pageno: i64) -> Result<(), crate::Error> {
+        self.0.pageno = new_pageno
+            .try_into()
+            .map_err(|_| crate::Error::TypeCastingError)?;
+        Ok(())
     }
 
     pub fn get_packetno(&self) -> i64 {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -35,6 +35,18 @@ impl Stream {
         self.0.lacing_returned
     }
 
+    pub fn get_body_storage(&self) -> i64 {
+        self.0.body_storage
+    }
+
+    pub fn get_body_fill(&self) -> i64 {
+        self.0.body_fill
+    }
+
+    pub fn get_body_returned(&self) -> i64 {
+        self.0.body_returned
+    }
+    
     pub fn get_header(&self) -> &[u8; 282] {
         &self.0.header
     }


### PR DESCRIPTION
As mentioned in #1 libogg-rs will not build on windows because the type of c_long is actually different. 
This casts the i32 on windows into i64s where possible (this cast will never fail). On Linux it will result in a needles cast from i64 to i64 as c_long is already i64 there. 
Where we need to downcast on windows from i64 to i32 I added a try_into(). The function can fail now and therefore returns a Result<()>. For this I added the new error `Error::TypeCastingError` as "Internal libogg error" does not really fit here. 

- adds `#[non_exhaustive]` to your errors enum, because adding new errors could otherwise break user code, when they have a match statement over the errors for example they would need to add new match arms as their match would not cover every possibility anymore. (Correct me if I'm wrong here. I am also very new to writing Rust crates)

- adds some more getter functions for the Stream struct because I needed them in my code. Feel free to cherry pick if you don't want that. 